### PR TITLE
refactor(anvilcraft): 升级 AnvilCraft 至 1.5.0 版本并调整相关 API

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,8 +21,3 @@ mod_version=0.0.3
 mod_group_id=me.theabab2333
 mod_authors=theabab2333
 mod_description=Tap on the head
-## Dependencies Info
-anvilcraft_version=1.4.11+build.1220
-registrate_version=MC1.21-1.3.0+62
-jei_version=19.21.0.247
-curios_version=9.0.15+1.21.1

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 neoForge = "21.1.186"
 registrate = "MC1.21-1.3.0+62"
 clothConfig = "15.0.140"
-anvilCraft = "1.4.11+build.1220"
+anvilCraft = "1.5.0+build.1304"
 curios = "9.0.15+1.21.1"
 jei = "19.21.0.247"
 jade = "15.3.4+neoforge"

--- a/src/main/java/me/theabab2333/headtap/anvil/HitBuddingBlockBehavior.java
+++ b/src/main/java/me/theabab2333/headtap/anvil/HitBuddingBlockBehavior.java
@@ -1,7 +1,7 @@
 package me.theabab2333.headtap.anvil;
 
 import dev.dubhe.anvilcraft.api.anvil.IAnvilBehavior;
-import dev.dubhe.anvilcraft.api.event.anvil.AnvilFallOnLandEvent;
+import dev.dubhe.anvilcraft.api.event.AnvilEvent;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.util.RandomSource;
@@ -15,15 +15,8 @@ import net.minecraft.world.level.material.Fluids;
 import static net.minecraft.world.level.block.BuddingAmethystBlock.canClusterGrowAtState;
 
 public class HitBuddingBlockBehavior implements IAnvilBehavior {
-
     @Override
-    public boolean handle(
-        Level level,
-        BlockPos hitBlockPos,
-        BlockState hitBlockState,
-        float fallDistance,
-        AnvilFallOnLandEvent event
-    ) {
+    public boolean handle(Level level, BlockPos hitBlockPos, BlockState hitBlockState, float fallDistance, AnvilEvent.OnLand event) {
         Direction[] DIRECTIONS = Direction.values();
         RandomSource random = level.getRandom();
         Direction direction = DIRECTIONS[random.nextInt(DIRECTIONS.length)];

--- a/src/main/java/me/theabab2333/headtap/anvil/HitEntityEjectorBehavior.java
+++ b/src/main/java/me/theabab2333/headtap/anvil/HitEntityEjectorBehavior.java
@@ -1,7 +1,7 @@
 package me.theabab2333.headtap.anvil;
 
 import dev.dubhe.anvilcraft.api.anvil.IAnvilBehavior;
-import dev.dubhe.anvilcraft.api.event.anvil.AnvilFallOnLandEvent;
+import dev.dubhe.anvilcraft.api.event.AnvilEvent;
 import me.theabab2333.headtap.block.EntityEjectorBlock;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
@@ -9,13 +9,9 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 
 public class HitEntityEjectorBehavior implements IAnvilBehavior {
+
     @Override
-    public boolean handle(
-        Level level,
-        BlockPos hitBlockPos,
-        BlockState hitBlockState,
-        float fallDistance,
-        AnvilFallOnLandEvent event) {
+    public boolean handle(Level level, BlockPos hitBlockPos, BlockState hitBlockState, float fallDistance, AnvilEvent.OnLand event) {
         Block block = hitBlockState.getBlock();
         if (block instanceof EntityEjectorBlock entityEjectorBlock) {
             int count = (int) fallDistance + 1;

--- a/src/main/java/me/theabab2333/headtap/anvil/HitPassiveRoyalAnvilBehavior.java
+++ b/src/main/java/me/theabab2333/headtap/anvil/HitPassiveRoyalAnvilBehavior.java
@@ -1,7 +1,7 @@
 package me.theabab2333.headtap.anvil;
 
 import dev.dubhe.anvilcraft.api.anvil.IAnvilBehavior;
-import dev.dubhe.anvilcraft.api.event.anvil.AnvilFallOnLandEvent;
+import dev.dubhe.anvilcraft.api.event.AnvilEvent;
 import me.theabab2333.headtap.block.entity.PassiveRoyalAnvilBlockEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
@@ -9,7 +9,7 @@ import net.minecraft.world.level.block.state.BlockState;
 
 public class HitPassiveRoyalAnvilBehavior implements IAnvilBehavior {
     @Override
-    public boolean handle(Level level, BlockPos hitBlockPos, BlockState hitBlockState, float fallDistance, AnvilFallOnLandEvent event) {
+    public boolean handle(Level level, BlockPos hitBlockPos, BlockState hitBlockState, float fallDistance, AnvilEvent.OnLand event) {
         if (!hitBlockState.hasBlockEntity()) return false;
         PassiveRoyalAnvilBlockEntity blockEntity = (PassiveRoyalAnvilBlockEntity) level.getBlockEntity(hitBlockPos);
         if (blockEntity == null) return false;

--- a/src/main/java/me/theabab2333/headtap/anvil/HitPassiveRoyalGrindstoneBehavior.java
+++ b/src/main/java/me/theabab2333/headtap/anvil/HitPassiveRoyalGrindstoneBehavior.java
@@ -1,15 +1,16 @@
 package me.theabab2333.headtap.anvil;
 
 import dev.dubhe.anvilcraft.api.anvil.IAnvilBehavior;
-import dev.dubhe.anvilcraft.api.event.anvil.AnvilFallOnLandEvent;
+import dev.dubhe.anvilcraft.api.event.AnvilEvent;
 import me.theabab2333.headtap.block.entity.PassiveRoyalGrindstoneBlockEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 
 public class HitPassiveRoyalGrindstoneBehavior implements IAnvilBehavior {
+
     @Override
-    public boolean handle(Level level, BlockPos hitBlockPos, BlockState hitBlockState, float fallDistance, AnvilFallOnLandEvent event) {
+    public boolean handle(Level level, BlockPos hitBlockPos, BlockState hitBlockState, float fallDistance, AnvilEvent.OnLand event) {
         if (!hitBlockState.hasBlockEntity()) return false;
         PassiveRoyalGrindstoneBlockEntity blockEntity = (PassiveRoyalGrindstoneBlockEntity) level.getBlockEntity(hitBlockPos);
         if (blockEntity == null) return false;

--- a/src/main/java/me/theabab2333/headtap/anvil/HitPassiveRoyalSmithingTableBehavior.java
+++ b/src/main/java/me/theabab2333/headtap/anvil/HitPassiveRoyalSmithingTableBehavior.java
@@ -1,15 +1,16 @@
 package me.theabab2333.headtap.anvil;
 
 import dev.dubhe.anvilcraft.api.anvil.IAnvilBehavior;
-import dev.dubhe.anvilcraft.api.event.anvil.AnvilFallOnLandEvent;
+import dev.dubhe.anvilcraft.api.event.AnvilEvent;
 import me.theabab2333.headtap.block.entity.PassiveRoyalSmithingTableBlockEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 
 public class HitPassiveRoyalSmithingTableBehavior implements IAnvilBehavior {
+
     @Override
-    public boolean handle(Level level, BlockPos hitBlockPos, BlockState hitBlockState, float fallDistance, AnvilFallOnLandEvent event) {
+    public boolean handle(Level level, BlockPos hitBlockPos, BlockState hitBlockState, float fallDistance, AnvilEvent.OnLand event) {
         if (!hitBlockState.hasBlockEntity()) return false;
         PassiveRoyalSmithingTableBlockEntity blockEntity = (PassiveRoyalSmithingTableBlockEntity) level.getBlockEntity(hitBlockPos);
         if (blockEntity == null) return false;

--- a/src/main/java/me/theabab2333/headtap/anvil/HitPrinterBlockBehavior.java
+++ b/src/main/java/me/theabab2333/headtap/anvil/HitPrinterBlockBehavior.java
@@ -1,15 +1,16 @@
 package me.theabab2333.headtap.anvil;
 
 import dev.dubhe.anvilcraft.api.anvil.IAnvilBehavior;
-import dev.dubhe.anvilcraft.api.event.anvil.AnvilFallOnLandEvent;
+import dev.dubhe.anvilcraft.api.event.AnvilEvent;
 import me.theabab2333.headtap.block.entity.PrinterBlockEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 
 public class HitPrinterBlockBehavior implements IAnvilBehavior {
+
     @Override
-    public boolean handle(Level level, BlockPos hitBlockPos, BlockState hitBlockState, float fallDistance, AnvilFallOnLandEvent event) {
+    public boolean handle(Level level, BlockPos hitBlockPos, BlockState hitBlockState, float fallDistance, AnvilEvent.OnLand event) {
         if (!hitBlockState.hasBlockEntity()) return false;
         PrinterBlockEntity blockEntity = (PrinterBlockEntity) level.getBlockEntity(hitBlockPos);
         if (blockEntity == null) return false;

--- a/src/main/java/me/theabab2333/headtap/anvil/HitResinExtractorBehavior.java
+++ b/src/main/java/me/theabab2333/headtap/anvil/HitResinExtractorBehavior.java
@@ -1,21 +1,16 @@
 package me.theabab2333.headtap.anvil;
 
 import dev.dubhe.anvilcraft.api.anvil.IAnvilBehavior;
-import dev.dubhe.anvilcraft.api.event.anvil.AnvilFallOnLandEvent;
+import dev.dubhe.anvilcraft.api.event.AnvilEvent;
 import me.theabab2333.headtap.block.entity.ResinExtractorBlockEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 
 public class HitResinExtractorBehavior implements IAnvilBehavior {
+
     @Override
-    public boolean handle(
-        Level level,
-        BlockPos hitBlockPos,
-        BlockState hitBlockState,
-        float fallDistance,
-        AnvilFallOnLandEvent event
-    ) {
+    public boolean handle(Level level, BlockPos hitBlockPos, BlockState hitBlockState, float fallDistance, AnvilEvent.OnLand event) {
         if (!hitBlockState.hasBlockEntity()) return false;
         ResinExtractorBlockEntity blockEntity = (ResinExtractorBlockEntity) level.getBlockEntity(hitBlockPos);
         if (blockEntity == null) return false;

--- a/src/main/java/me/theabab2333/headtap/anvil/HitStoneGeneratorBehavior.java
+++ b/src/main/java/me/theabab2333/headtap/anvil/HitStoneGeneratorBehavior.java
@@ -1,21 +1,16 @@
 package me.theabab2333.headtap.anvil;
 
 import dev.dubhe.anvilcraft.api.anvil.IAnvilBehavior;
-import dev.dubhe.anvilcraft.api.event.anvil.AnvilFallOnLandEvent;
+import dev.dubhe.anvilcraft.api.event.AnvilEvent;
 import me.theabab2333.headtap.block.entity.StoneGeneratorBlockEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 
 public class HitStoneGeneratorBehavior implements IAnvilBehavior {
+
     @Override
-    public boolean handle(
-        Level level,
-        BlockPos hitBlockPos,
-        BlockState hitBlockState,
-        float fallDistance,
-        AnvilFallOnLandEvent event
-    ) {
+    public boolean handle(Level level, BlockPos hitBlockPos, BlockState hitBlockState, float fallDistance, AnvilEvent.OnLand event) {
         if (!hitBlockState.hasBlockEntity()) return false;
         StoneGeneratorBlockEntity blockEntity = (StoneGeneratorBlockEntity) level.getBlockEntity(hitBlockPos);
         if (blockEntity == null) return false;

--- a/src/main/java/me/theabab2333/headtap/block/BuilderBlock.java
+++ b/src/main/java/me/theabab2333/headtap/block/BuilderBlock.java
@@ -113,7 +113,7 @@ public class BuilderBlock extends BetterBaseEntityBlock implements HammerRotateB
     ) {
         if (state.is(newState.getBlock())) return;
         if (level.getBlockEntity(pos) instanceof BuilderBlockEntity entity) {
-            FilteredItemStackHandler itemHandler = entity.getFilteredItemDepository();
+            FilteredItemStackHandler itemHandler = entity.getFilteredItemStackHandler();
             Containers.dropContents(level, pos, itemHandler.getStacks());
             level.updateNeighbourForOutputSignal(pos, this);
         }

--- a/src/main/java/me/theabab2333/headtap/block/PassiveRoyalAnvilBlock.java
+++ b/src/main/java/me/theabab2333/headtap/block/PassiveRoyalAnvilBlock.java
@@ -55,7 +55,7 @@ public class PassiveRoyalAnvilBlock extends BetterBaseEntityBlock implements IHa
         if (state.is(newState.getBlock())) return;
         if (level.getBlockEntity(pos) instanceof PassiveRoyalAnvilBlockEntity entity) {
             Vec3 vec3 = entity.getBlockPos().getCenter();
-            FilteredItemStackHandler depository = entity.getFilteredItemDepository();
+            FilteredItemStackHandler depository = entity.getFilteredItemStackHandler();
             for (int slot = 0; slot < depository.getSlots(); slot++) {
                 Containers.dropItemStack(level, vec3.x, vec3.y, vec3.z, depository.getStackInSlot(slot));
             }

--- a/src/main/java/me/theabab2333/headtap/block/PassiveRoyalSmithingTableBlock.java
+++ b/src/main/java/me/theabab2333/headtap/block/PassiveRoyalSmithingTableBlock.java
@@ -51,7 +51,7 @@ public class PassiveRoyalSmithingTableBlock extends BetterBaseEntityBlock implem
         if (state.is(newState.getBlock())) return;
         if (level.getBlockEntity(pos) instanceof PassiveRoyalSmithingTableBlockEntity entity) {
             Vec3 vec3 = entity.getBlockPos().getCenter();
-            FilteredItemStackHandler depository = entity.getFilteredItemDepository();
+            FilteredItemStackHandler depository = entity.getFilteredItemStackHandler();
             for (int slot = 0; slot < depository.getSlots(); slot++) {
                 Containers.dropItemStack(level, vec3.x, vec3.y, vec3.z, depository.getStackInSlot(slot));
             }

--- a/src/main/java/me/theabab2333/headtap/block/PrinterBlock.java
+++ b/src/main/java/me/theabab2333/headtap/block/PrinterBlock.java
@@ -74,7 +74,7 @@ public class PrinterBlock extends BetterBaseEntityBlock implements IHammerRemova
         if (state.is(newState.getBlock())) return;
         if (level.getBlockEntity(pos) instanceof PrinterBlockEntity entity) {
             Vec3 vec3 = entity.getBlockPos().getCenter();
-            FilteredItemStackHandler depository = entity.getFilteredItemDepository();
+            FilteredItemStackHandler depository = entity.getFilteredItemStackHandler();
             for (int slot = 0; slot < depository.getSlots(); slot++) {
                 Containers.dropItemStack(level, vec3.x, vec3.y, vec3.z, depository.getStackInSlot(slot));
             }

--- a/src/main/java/me/theabab2333/headtap/block/entity/BuilderBlockEntity.java
+++ b/src/main/java/me/theabab2333/headtap/block/entity/BuilderBlockEntity.java
@@ -213,11 +213,6 @@ public class BuilderBlockEntity extends BaseMachineBlockEntity implements IFilte
         getLevel().setBlockAndUpdate(getBlockPos(), state.setValue(BuilderBlock.FACING, direction));
     }
 
-    @Override
-    public FilteredItemStackHandler getFilteredItemDepository() {
-        return itemHandler;
-    }
-
     public static void registerCapabilities(RegisterCapabilitiesEvent event) {
         event.registerBlockEntity(
             Capabilities.ItemHandler.BLOCK,
@@ -258,5 +253,10 @@ public class BuilderBlockEntity extends BaseMachineBlockEntity implements IFilte
     @Override
     public void updateDisplayItem(ItemStack stack) {
         displayItemStack = stack;
+    }
+
+    @Override
+    public FilteredItemStackHandler getFilteredItemStackHandler() {
+        return itemHandler;
     }
 }

--- a/src/main/java/me/theabab2333/headtap/block/entity/PassiveRoyalAnvilBlockEntity.java
+++ b/src/main/java/me/theabab2333/headtap/block/entity/PassiveRoyalAnvilBlockEntity.java
@@ -84,7 +84,7 @@ public class PassiveRoyalAnvilBlockEntity extends BlockEntity implements IItemHa
                 j = i == j ? j + 1 : Math.max(j, i);
                 Enchantment enchantment = holder.value();
 
-                if (!AnvilCraft.config.royalAnvilBeyondMaxLevel && j > enchantment.getMaxLevel()) {
+                if (!AnvilCraft.CONFIG.royalAnvilBeyondMaxLevel && j > enchantment.getMaxLevel()) {
                     j = enchantment.getMaxLevel();
                 }
                 inputEnchantments.set(holder, j);
@@ -105,11 +105,6 @@ public class PassiveRoyalAnvilBlockEntity extends BlockEntity implements IItemHa
 
     @Override
     public IItemHandler getItemHandler() {
-        return itemHandler;
-    }
-
-    @Override
-    public FilteredItemStackHandler getFilteredItemDepository() {
         return itemHandler;
     }
 
@@ -136,5 +131,10 @@ public class PassiveRoyalAnvilBlockEntity extends BlockEntity implements IItemHa
     public ItemStack getResult() {
         setBook();
         return getResult(bookRight, bookLeft);
+    }
+
+    @Override
+    public FilteredItemStackHandler getFilteredItemStackHandler() {
+        return itemHandler;
     }
 }

--- a/src/main/java/me/theabab2333/headtap/block/entity/PassiveRoyalGrindstoneBlockEntity.java
+++ b/src/main/java/me/theabab2333/headtap/block/entity/PassiveRoyalGrindstoneBlockEntity.java
@@ -25,6 +25,7 @@ import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
+import net.neoforged.neoforge.items.IItemHandler;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -120,10 +121,6 @@ public class PassiveRoyalGrindstoneBlockEntity extends BlockEntity implements II
         return itemHandler;
     }
 
-    public FilteredItemStackHandler getItemHandler() {
-        return itemHandler;
-    }
-
     public static void registerCapabilities(RegisterCapabilitiesEvent event) {
         event.registerBlockEntity(
             Capabilities.ItemHandler.BLOCK,
@@ -139,5 +136,15 @@ public class PassiveRoyalGrindstoneBlockEntity extends BlockEntity implements II
     public void loadAdditional(CompoundTag tag, HolderLookup.Provider provider) {
         super.loadAdditional(tag, provider);
         itemHandler.deserializeNBT(provider, tag.getCompound("Inv"));
+    }
+
+    @Override
+    public FilteredItemStackHandler getFilteredItemStackHandler() {
+        return itemHandler;
+    }
+
+    @Override
+    public IItemHandler getItemHandler() {
+        return itemHandler;
     }
 }

--- a/src/main/java/me/theabab2333/headtap/block/entity/PassiveRoyalSmithingTableBlockEntity.java
+++ b/src/main/java/me/theabab2333/headtap/block/entity/PassiveRoyalSmithingTableBlockEntity.java
@@ -107,11 +107,6 @@ public class PassiveRoyalSmithingTableBlockEntity extends BlockEntity implements
     }
 
     @Override
-    public FilteredItemStackHandler getFilteredItemDepository() {
-        return itemHandler;
-    }
-
-    @Override
     public IItemHandler getItemHandler() {
         return itemHandler;
     }
@@ -134,5 +129,10 @@ public class PassiveRoyalSmithingTableBlockEntity extends BlockEntity implements
     public void loadAdditional(@NotNull CompoundTag tag, HolderLookup.Provider provider) {
         super.loadAdditional(tag, provider);
         itemHandler.deserializeNBT(provider, tag.getCompound("Inv"));
+    }
+
+    @Override
+    public FilteredItemStackHandler getFilteredItemStackHandler() {
+        return itemHandler;
     }
 }

--- a/src/main/java/me/theabab2333/headtap/block/entity/PrinterBlockEntity.java
+++ b/src/main/java/me/theabab2333/headtap/block/entity/PrinterBlockEntity.java
@@ -142,16 +142,16 @@ public class PrinterBlockEntity extends BlockEntity implements IFilterBlockEntit
         return ClientboundBlockEntityDataPacket.create(this);
     }
 
-    @Override
-    public FilteredItemStackHandler getFilteredItemDepository() {
-        return itemHandler;
-    }
-
     public int getNeedB() {
         return bCount;
     }
 
     public int getNeedC() {
         return cCount;
+    }
+
+    @Override
+    public FilteredItemStackHandler getFilteredItemStackHandler() {
+        return itemHandler;
     }
 }

--- a/src/main/java/me/theabab2333/headtap/data/recipe/AnvilCraftRecipeLoader.java
+++ b/src/main/java/me/theabab2333/headtap/data/recipe/AnvilCraftRecipeLoader.java
@@ -1,7 +1,7 @@
 package me.theabab2333.headtap.data.recipe;
 
 import com.tterrag.registrate.providers.RegistrateRecipeProvider;
-import dev.dubhe.anvilcraft.recipe.anvil.BlockCompressRecipe;
+import dev.dubhe.anvilcraft.recipe.anvil.wrap.BlockCompressRecipe;
 import me.theabab2333.headtap.init.ModBlocks;
 
 public class AnvilCraftRecipeLoader {

--- a/src/main/java/me/theabab2333/headtap/event/AnvilEventListener.java
+++ b/src/main/java/me/theabab2333/headtap/event/AnvilEventListener.java
@@ -1,6 +1,6 @@
 package me.theabab2333.headtap.event;
 
-import dev.dubhe.anvilcraft.api.event.anvil.AnvilFallOnLandEvent;
+import dev.dubhe.anvilcraft.api.event.AnvilEvent;
 import dev.dubhe.anvilcraft.block.PiezoelectricCrystalBlock;
 import me.theabab2333.headtap.HeadTap;
 import me.theabab2333.headtap.block.AnvilObserverBlock;
@@ -21,7 +21,7 @@ import java.util.List;
 public class AnvilEventListener {
     private static boolean behaviorRegistered = false;
     @SubscribeEvent
-    public static void onLand(@NotNull AnvilFallOnLandEvent event){
+    public static void onLand(@NotNull AnvilEvent.OnLand event){
         if (!behaviorRegistered) {
             ModAnvilBehaviors.register();
             PiezoelectricCrystalBlock.ANVIL_TYPES.put(ModBlocks.AMETHYST_ANVIL.get(), List.of(2, 4, 6, 8));

--- a/src/main/java/me/theabab2333/headtap/mixin/ResinBlockItemMixin.java
+++ b/src/main/java/me/theabab2333/headtap/mixin/ResinBlockItemMixin.java
@@ -4,6 +4,7 @@ import dev.dubhe.anvilcraft.init.ModComponents;
 import dev.dubhe.anvilcraft.init.ModItems;
 import dev.dubhe.anvilcraft.item.HasMobBlockItem;
 import dev.dubhe.anvilcraft.item.ResinBlockItem;
+import dev.dubhe.anvilcraft.item.property.component.SavedEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.InteractionResult;


### PR DESCRIPTION
- 更新 AnvilCraft 依赖版本至 1.5.0+build.1304
- 调整导入路径以适应新版本 API- 修改事件处理方法以使用新的 AnvilEvent 类
- 重命名方法以符合新 API，例如 getFilteredItemDepository 改为 getFilteredItemStackHandler
- 删除未使用的旧 API 导入