### PR TITLE
ci(workflows): 添加游戏测试步骤到CI和PR工作流

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,15 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USER }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASS }}
         continue-on-error: true
+
+      - name: gametest
+        uses: Anvil-Dev/dedicated-server-launch-test@1.21.1-neoforge
+        continue-on-error: false
+        with:
+          mod: build/libs/${{ steps.properties.outputs.mod_id }}-neoforge-${{ steps.version.outputs.version }}.jar
+          extra-mods: |
+            anvilcraft:1.21.1-1.5.0+hotfix.1570
+          maven-repos: |
+            https://server.cjsah.net:1002/maven
+          maven-mods: |
+            dev.anvilcraft.lib:anvillib-neoforge-1.21.1:1.4.0+build.172

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -57,3 +57,15 @@ jobs:
         with:
           name: "${{ steps.properties.outputs.mod_name }}-${{ steps.properties.outputs.mod_version }}${{ steps.version.outputs.version }}"
           path: build/libs/AnvilCraftHeadTap-${{ steps.properties.outputs.mod_version }}${{ steps.version.outputs.version }}.jar
+
+      - name: gametest
+        uses: Anvil-Dev/dedicated-server-launch-test@1.21.1-neoforge
+        continue-on-error: false
+        with:
+          mod: build/libs/${{ steps.properties.outputs.mod_id }}-neoforge-${{ steps.version.outputs.version }}.jar
+          extra-mods: |
+            anvilcraft:1.21.1-1.5.0+hotfix.1570
+          maven-repos: |
+            https://server.cjsah.net:1002/maven
+          maven-mods: |
+            dev.anvilcraft.lib:anvillib-neoforge-1.21.1:1.4.0+build.172


### PR DESCRIPTION
- 在ci.yml中添加gametest步骤，使用Anvil-Dev/dedicated-server-launch-test
- 在pull_request.yml中添加gametest步骤，配置相同的测试参数
- 设置mod参数指向构建的jar文件
- 配置额外依赖mod anvilcraft和anvillib
- 添加maven仓库地址用于下载依赖
- 设置continue-on-error为false以确保测试失败时工作流失败